### PR TITLE
Fix: lateral position and sim check, Add: steering action type

### DIFF
--- a/sumo_gym/params.py
+++ b/sumo_gym/params.py
@@ -1,6 +1,15 @@
 class SimulationConstants:
     def __init__(self):
         self.num_features = 10
+        '''
+        Action type: choose between the following actions
+        acceleration:
+            Action = [acceleration_x, acceleration_y]
+        acc_steering:
+            Action = [acceleration, steering]
+            update according to bicycle model, where the reference point is center of gravity
+        '''
+        self.action_type = "acceleration"
 
 
 class IDMConstants:

--- a/sumo_gym/params.py
+++ b/sumo_gym/params.py
@@ -2,7 +2,7 @@ class SimulationConstants:
     def __init__(self):
         self.num_features = 10
         '''
-        Action type: choose between the following actions
+        Action type: choose between the following action types
         acceleration:
             Action = [acceleration_x, acceleration_y]
         acc_steering:

--- a/sumo_gym/sumo_gym.py
+++ b/sumo_gym/sumo_gym.py
@@ -101,7 +101,7 @@ class SumoGym(gym.Env):
                     chosen_file = all_config_files[choice]
                 else:
                     sys.exit('Chosen file is not available')
-            self._cfg = config_dir + '/' + "highway-100.sumocfg"
+            self._cfg = config_dir + '/' + chosen_file # "highway-100.sumocfg"
         elif self.scenario == "custom":
             self._cfg = input("Please enter your custom .sumocfg filename:\n")
         else:
@@ -368,7 +368,7 @@ class SumoGym(gym.Env):
             speed = math.sqrt(vx ** 2 + vy ** 2)
             # return heading in degrees
             # heading = (math.atan(vy / (vx + 1e-12))
-            heading = math.atan(math.radians(angle) + (vy / (vx + 1e-12)))
+            heading = math.atan(vy / (vx + 1e-12)) + math.radians(angle)
 
             acc_x, acc_y = self.ego_state['ax'], self.ego_state['ay']
             acc_x += (ax_cmd - acc_x) * self.delta_t

--- a/sumo_gym/sumo_gym.py
+++ b/sumo_gym/sumo_gym.py
@@ -444,6 +444,17 @@ class SumoGym(gym.Env):
             self.ego_state['ax'], self.ego_state['ay'] = acc_x, acc_y
             info["debug"] = [lat_dist, self.ego_state['lane_y']]
             traci.simulationStep()
+        
+        # sim check after traci update
+        lane = traci.vehicle.getLaneIndex(self.egoID)
+        lane_id = traci.vehicle.getLaneID(self.egoID)
+        if in_road == False or lane_id == "":
+            info["debug"] = "Ego-vehicle is out of network"
+            sim_check = True
+        elif self.egoID in traci.simulation.getCollidingVehiclesIDList():
+            info["debug"] = "A crash happened to the Ego-vehicle"
+            sim_check = True
+        
         reward = self.reward(action)
 
         return obs, reward, sim_check, info

--- a/sumo_gym/sumo_gym.py
+++ b/sumo_gym/sumo_gym.py
@@ -342,24 +342,25 @@ class SumoGym(gym.Env):
             acceleration = action[0]
             delta_f = action[1]
             beta = np.arctan(1 / 2 * np.tan(delta_f))
+            length = traci.vehicle.getLength(self.egoID)
             # update x
             vx, vy = self.ego_state['vx'], self.ego_state['vy']
-            heading = (math.atan(vy/ (vx+ 1e-12)))
+            heading = math.atan(vy / (vx + 1e-12))
             pre_speed = math.sqrt(vx ** 2 + vy ** 2)
             vx, vy = pre_speed * np.array([np.cos(heading + beta),
                                    np.sin(heading + beta)])
             long_distance = vx * self.delta_t
             lat_distance = vy * self.delta_t
             distance = math.sqrt(vx ** 2 + vy ** 2) * self.delta_t
-            # update v
-            length = traci.vehicle.getLength(self.egoID)
-            heading = pre_speed * np.sin(beta) / (length / 2) * self.delta_t
-            speed = pre_speed + acceleration * self.delta_t
-            vx, vy = speed * np.array([np.cos(heading), np.sin(heading)])
             # update a
             acc_x = (vx - self.ego_state['vx']) / self.delta_t
             acc_y = (vy - self.ego_state['vy']) / self.delta_t
-            print("steering action: ", acceleration, delta_f, "\tacceleration: ", acc_x, acc_y)
+            # update v
+            heading += pre_speed * np.sin(beta) / (length / 2) * self.delta_t
+            speed = pre_speed + acceleration * self.delta_t
+            vx, vy = speed * np.array([np.cos(heading), np.sin(heading)])
+            heading += math.radians(angle) # Add angle between road and world coordinate
+            # print("steering action: ", acceleration, delta_f, "\tacceleration: ", acc_x, acc_y)
         elif self.params.action_type == "acceleration":
             ax_cmd = action[0]
             ay_cmd = action[1]

--- a/sumo_gym/sumo_gym.py
+++ b/sumo_gym/sumo_gym.py
@@ -409,16 +409,23 @@ class SumoGym(gym.Env):
         sim_check = False
         obs = []
         info = {}
+        
+        # sim check before traci update
         if in_road == False or lane_id == "":
             info["debug"] = "Ego-vehicle is out of network"
             sim_check = True
         elif self.egoID in traci.simulation.getCollidingVehiclesIDList():
             info["debug"] = "A crash happened to the Ego-vehicle"
             sim_check = True
-
+        
         else:
-            self.ego_state['lane_x'] += long_dist
-            self.ego_state['lane_y'] += lat_dist
+            # update lane_x and lane_y (based on true value instead of ego_state)
+            y = traci.vehicle.getLateralLanePosition(self.egoID)
+            lane_id = traci.vehicle.getLaneID(self.egoID)
+            lane_index = traci.vehicle.getLaneIndex(self.egoID)
+            lane_width = traci.lane.getWidth(lane_id)
+            self.ego_state['lane_x'] = traci.vehicle.getLanePosition(self.egoID) + long_dist
+            self.ego_state['lane_y'] = lane_width * (lane_index + 0.5) + y + lat_dist
             # print(self.ego_state['lane_y'])
             new_x = self.ego_state['x'] + dx
             new_y = self.ego_state['y'] + dy


### PR DESCRIPTION
1. The lateral position was updated based on the calculated ego state, which may lead to accumulated error. Now it's updated based on the actual value from Traci.
2. Sim check was performed before state update in Traci. If the vehicle crashes, we must wait for the next simulation step, and problems may occur in the reward function. Thus, another sim check is added after the state update in Traci. 
3. A new action type "acc_steering" is added. Action = [acceleration, steering angle]